### PR TITLE
Remove macOS 15 Intel target from build_dist.yml

### DIFF
--- a/.github/workflows/build_dist.yml
+++ b/.github/workflows/build_dist.yml
@@ -43,8 +43,6 @@ jobs:
             target: linux
           - os: windows-latest
             target: windows
-          - os: macos-15-intel
-            target: macos-x86_64
           - os: macos-14
             target: macos-arm64
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
# Description

This pull request updates the build matrix in the GitHub Actions workflow to remove support for building on Intel-based macOS runners. The workflow will now only build for ARM-based macOS, Windows, and Linux targets.

Build matrix update:

* Removed the `macos-15-intel` runner and its associated `macos-x86_64` build target from the GitHub Actions workflow, so builds will no longer run on Intel-based macOS environments. (`.github/workflows/build_dist.yml`)

------------------------------------------------------------------------------------------------------------

# Checklist

Please complete the following checklist when submitting a PR. The PR will not be reviewed until all items are checked.

- [x] All new features include a unit test.
      Make sure that the tests passed and the coverage is
      sufficient by running
      `uv run pytest --session-timeout=600`.
- [x] All new functions and code are clearly documented.
- [x] The code passes all pre-commit hooks.
      You can do this by running `uvx pre-commit run --all-files`.
- [x] The code is type-checked using Mypy.
      You can do this by running `uv run mypy src tests`.
